### PR TITLE
Fixed field focus outline

### DIFF
--- a/acute/test-pages/TestAcuteSelect.htm
+++ b/acute/test-pages/TestAcuteSelect.htm
@@ -13,6 +13,9 @@
     <link href="../acute.select/acute.select.css" rel="stylesheet" />
     <script type="text/javascript" src="TestAcuteSelect.js"></script>
     <style>
+        *:focus {
+            outline: 0;
+        }
         body {
             padding: 10px;
         }


### PR DESCRIPTION
It was causing an odd visual issue in Chrome on Mac OS, so I've set `outline: 0;`

![](http://i.imgur.com/S7MTy90.gif)
