### PR TITLE
Revert "Fixed field focus outline"

### DIFF
--- a/acute/test-pages/TestAcuteSelect.htm
+++ b/acute/test-pages/TestAcuteSelect.htm
@@ -13,9 +13,6 @@
     <link href="../acute.select/acute.select.css" rel="stylesheet" />
     <script type="text/javascript" src="TestAcuteSelect.js"></script>
     <style>
-        *:focus {
-            outline: 0;
-        }
         body {
             padding: 10px;
         }


### PR DESCRIPTION
After looking into this a bit more, I've realised it needs a bit more thought. Firstly, the css change is in the test page, so wouldn't change the directive's behaviour without being applied to the main css, but more importantly, removing the focus outline completely is not good practise, as it lets users see when a control has the focus. It looks odd on OSX because it's appearing around the opened dropdown list as well as the search box for some reason. I'll see if it's possible to tidy that up.
