### PR TITLE
Dynamic directory path for template folder

### DIFF
--- a/acute/acute.select/acute.select.js
+++ b/acute/acute.select/acute.select.js
@@ -1040,8 +1040,12 @@ angular.module("acute.select", [])
 // Service to allow host pages to change settings for all instances (in their module.run function)
 .factory('acuteSelectService', function() {
 
+    // Get directory of script
+    var fileName = "acute.select.js";
+    var directory = document.querySelector('script[src$="' + fileName + '"]').getAttribute('src').replace(fileName,"");
+    
     var defaultSettings = {
-        "templatePath": "/acute.select/template",
+        "templatePath": directory + "template",
         "noItemsText": "No items found.",
         "placeholderText": "Please select...",
         "itemHeight": 24,


### PR DESCRIPTION
Using a query to find the location of the current file so you can place the acute.select.js file in any folder.

For example, when in "components/acute-select/acute/acute.select/acute.select.js", javascript would try to load "/template" now will load "components/acute-select/acute/acute.select/template"